### PR TITLE
Fix correctness bugs in the ruckig port (C++ reference alignment)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,8 @@ julia = "1.11"
 
 [extras]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["JET", "Test"]
+test = ["JET", "Random", "Test"]

--- a/src/ruckig.jl
+++ b/src/ruckig.jl
@@ -18,6 +18,7 @@ const V_PRECISION = 1e-8
 const A_PRECISION = 1e-10
 const T_PRECISION = 1e-12
 const NEWTON_TOL = 1e-9  # Newton refinement tolerance (C++ uses 1e-9 for profile refinement)
+const T_MAX = 1e12  # Maximum profile duration accepted by check! (C++ profile.hpp t_max)
 
 # Include brake profile implementation
 include("ruckig_brake.jl")
@@ -187,10 +188,11 @@ end
 Create a BlockInterval from two profiles.
 Automatically determines left/right based on durations (matching C++ Interval constructor).
 The profile stored is the one with the longer duration (corresponding to `right`).
+Durations include the brake duration (C++ block.hpp adds brake.duration).
 """
 function BlockInterval(profile_left::RuckigProfile{T}, profile_right::RuckigProfile{T}) where T
-    left_duration = profile_left.t_sum[end]
-    right_duration = profile_right.t_sum[end]
+    left_duration = duration(profile_left)
+    right_duration = duration(profile_right)
     if left_duration < right_duration
         BlockInterval{T}(left_duration, right_duration, profile_right)
     else
@@ -313,9 +315,8 @@ function calculate_block!(vpc::ValidProfileCollection{T}) where T
         idx_other = 3 - idx_min
 
         p_min = profiles[idx_min]
-        t_min = p_min.t_sum[end]
         interval_a = BlockInterval(profiles[idx_min], profiles[idx_other])
-        return Block{T}(p_min, t_min, interval_a, nothing)
+        return Block{T}(p_min, duration(p_min), interval_a, nothing)
     end
 
     # For 4 profiles, try to remove near-duplicates (numerical issue handling)
@@ -355,26 +356,24 @@ function calculate_block!(vpc::ValidProfileCollection{T}) where T
     end
 
     p_min = profiles[idx_min]
-    t_min = p_min.t_sum[end]
+    t_min = duration(p_min)
 
     if valid_count == 3
-        # C++ block.hpp lines 108-113
-        # C++ uses (idx_min + 1) % 3 and (idx_min + 2) % 3 with 0-based indexing
-        # For Julia 1-based: if idx_min=1, others are 2,3; if idx_min=2, others are 3,1; if idx_min=3, others are 1,2
-        idx_else_1 = mod1(idx_min, 3) == idx_min ? mod1(idx_min + 1, 3) : mod1(idx_min + 1, 3)
+        # C++ block.hpp lines 108-113: cyclic order (idx_min + k) % 3, 0-based
+        idx_else_1 = mod1(idx_min + 1, 3)
         idx_else_2 = mod1(idx_min + 2, 3)
-        # Simpler: get the two indices that aren't idx_min
-        others = filter(i -> i != idx_min, 1:3)
-        idx_else_1, idx_else_2 = others[1], others[2]
 
         interval_a = BlockInterval(profiles[idx_else_1], profiles[idx_else_2])
         return Block{T}(p_min, t_min, interval_a, nothing)
 
     elseif valid_count == 5
-        # C++ block.hpp lines 115-128
-        # Get the 4 indices that aren't idx_min, in order
-        others = filter(i -> i != idx_min, 1:5)
-        idx_else_1, idx_else_2, idx_else_3, idx_else_4 = others[1], others[2], others[3], others[4]
+        # C++ block.hpp lines 115-128: cyclic order (idx_min + k) % 5, 0-based.
+        # The order matters here: the direction-based pairing test below compares
+        # the profiles that FOLLOW the minimum cyclically, not in ascending index order
+        idx_else_1 = mod1(idx_min + 1, 5)
+        idx_else_2 = mod1(idx_min + 2, 5)
+        idx_else_3 = mod1(idx_min + 3, 5)
+        idx_else_4 = mod1(idx_min + 4, 5)
 
         # Check direction pairing (C++ line 121)
         if profiles[idx_else_1].direction == profiles[idx_else_2].direction
@@ -441,9 +440,44 @@ Base.length(r::Roots) = r.count
     return r.r4
 end
 
+@inline function Base.setindex!(r::Roots, val, i)
+    if i == 1
+        r.r1 = val
+    elseif i == 2
+        r.r2 = val
+    elseif i == 3
+        r.r3 = val
+    else
+        r.r4 = val
+    end
+    val
+end
+
+# C++ roots::Set sorts its contents when begin() is called; consumers rely on
+# ascending order (e.g. picking the first crossing time). Insertion sort over
+# at most 4 slots; isless places NaN last, where the >= 0 iterator filter skips it.
+function sort_roots!(r::Roots)
+    @inbounds for i in 2:r.count
+        v = r[i]
+        j = i - 1
+        while j >= 1 && isless(v, r[j])
+            r[j+1] = r[j]
+            j -= 1
+        end
+        r[j+1] = v
+    end
+    r
+end
+
+# Iteration yields fewer elements than length(r) when negative/NaN roots are
+# stored, so the iterator size is unknown (keeps collect/comprehensions correct)
+Base.IteratorSize(::Type{<:Roots}) = Base.SizeUnknown()
+Base.eltype(::Type{Roots{T}}) where T = T
+
 # Iterator interface for for-loop consumption
-# Matches C++ PositiveSet behavior: only iterate over non-negative roots
+# Matches C++ PositiveSet behavior: ascending order, only non-negative roots
 function Base.iterate(r::Roots)
+    sort_roots!(r)
     for i in 1:r.count
         val = r[i]
         val >= 0 && return (val, i + 1)
@@ -768,9 +802,11 @@ end
 Check and finalize a second-order profile.
 """
 function check_for_second_order!(buf::ProfileBuffer{T}, p0, v0, pf, vf, aMax, aMin, vMax, vMin, limits, control_signs) where T
-    # Set all jerks to zero (second-order profile)
+    # Check for negative times
     for i in 1:7
-        buf.j[i] = zero(T)
+        if buf.t[i] < -EPS
+            return false
+        end
     end
 
     # Compute cumulative times
@@ -779,24 +815,29 @@ function check_for_second_order!(buf::ProfileBuffer{T}, p0, v0, pf, vf, aMax, aM
         buf.t_sum[i] = buf.t_sum[i-1] + buf.t[i]
     end
 
-    # Check for negative times
-    for i in 1:7
-        if buf.t[i] < -EPS
-            return false
-        end
-    end
+    # Reject numerically absurd durations (C++ profile.hpp: t_sum.back() > t_max)
+    buf.t_sum[7] > T_MAX && return false
 
-    # Set accelerations for each phase
-    # Phase 1: accelerate at aMax
-    # Phase 2: coast (a=0)
-    # Phase 3: decelerate at aMin
-    buf.a[1] = aMax
-    buf.a[2] = aMax  # End of phase 1
-    buf.a[3] = zero(T)  # Coast
-    buf.a[4] = aMin  # Deceleration
-    for i in 5:8
-        buf.a[i] = zero(T)
+    # Zero jerk (second-order profile); per-phase constant accelerations.
+    # C++ profile.hpp check_for_second_order: the a array holds the acceleration
+    # DURING each phase (used by the integration below and by evaluate_at)
+    for i in 1:7
+        buf.j[i] = zero(T)
     end
+    buf.a[1] = buf.t[1] > 0 ? aMax : zero(T)
+    buf.a[2] = zero(T)
+    buf.a[3] = buf.t[3] > 0 ? aMin : zero(T)
+    buf.a[4] = zero(T)
+    if control_signs == UDDU
+        buf.a[5] = buf.t[5] > 0 ? aMin : zero(T)
+        buf.a[6] = zero(T)
+        buf.a[7] = buf.t[7] > 0 ? aMax : zero(T)
+    else  # UDUD
+        buf.a[5] = buf.t[5] > 0 ? aMax : zero(T)
+        buf.a[6] = zero(T)
+        buf.a[7] = buf.t[7] > 0 ? aMin : zero(T)
+    end
+    buf.a[8] = zero(T)  # Final acceleration is zero for second-order position profiles
 
     # Set initial state
     buf.p[1] = p0
@@ -804,17 +845,8 @@ function check_for_second_order!(buf::ProfileBuffer{T}, p0, v0, pf, vf, aMax, aM
 
     # Integrate through phases (second-order: v' = a, no jerk)
     for i in 1:7
-        ai = i == 1 ? aMax : (i == 3 ? aMin : zero(T))
-        if i == 2  # Coast
-            ai = zero(T)
-        elseif i == 1  # Accelerate
-            ai = aMax
-        elseif i == 3  # Decelerate
-            ai = aMin
-        end
-
-        buf.v[i+1] = buf.v[i] + buf.t[i] * ai
-        buf.p[i+1] = buf.p[i] + buf.t[i] * (buf.v[i] + buf.t[i] * ai / 2)
+        buf.v[i+1] = buf.v[i] + buf.t[i] * buf.a[i]
+        buf.p[i+1] = buf.p[i] + buf.t[i] * (buf.v[i] + buf.t[i] * buf.a[i] / 2)
     end
 
     # Check final position and velocity
@@ -863,7 +895,7 @@ function calculate_trajectory(lim::AccelerationLimiter{T}; pf, p0=zero(T), v0=ze
     get_second_order_position_brake_trajectory!(brake, v0, vmax, vmin, amax, amin)
     ps, vs, as = finalize_second_order_brake!(brake, p0, v0, zero(T))
     brake_duration = brake.duration
-    brake_copy = brake_duration > 0 ? deepcopy(brake) : nothing
+    brake_copy = brake_duration > 0 ? copy(brake) : nothing
 
     p0_eff, v0_eff = ps, vs
     pd = pf - p0_eff
@@ -988,7 +1020,9 @@ function solve_cubic_real!(roots::Roots, a, b, c, d)
         push!(roots, u + v - p/3)
     elseif disc < -EPS
         m = 2 * sqrt(-aa/3)
-        θ = acos(3bb / (aa * m)) / 3
+        # Clamp: near disc ≈ 0 the argument can drift outside [-1, 1] and acos
+        # would throw a DomainError; C++ uses an atan-based form that never fails
+        θ = acos(clamp(3bb / (aa * m), -1.0, 1.0)) / 3
         for k in 0:2
             push!(roots, m * cos(θ - 2π*k/3) - p/3)
         end
@@ -1159,13 +1193,19 @@ end
 =============================================================================#
 
 """
-    check!(buf, control_signs, limits, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af) -> Bool
+    check!(buf, control_signs, limits, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af, set_limits) -> Bool
 
 Validate profile: check times >= 0, integrate, verify limits and final state.
 This matches the reference implementation's check() template function.
+
+`set_limits` corresponds to the C++ template flag of the same name: when true,
+boundary accelerations of limit-reaching profiles are snapped to the exact limit
+values (aMax/aMin). It is true only at the step-1 call sites that C++ instantiates
+with `set_limits = true` (LIMIT_ACC0_ACC1 and LIMIT_ACC1), never in step 2.
 """
 function check!(buf::ProfileBuffer{T}, control_signs::ControlSigns, limits::ReachedLimits,
-                jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af=zero(T)) where T
+                jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af=zero(T),
+                set_limits::Bool=false) where T
 
     # Set jerk pattern based on control signs
     # Note: jerk is set after times are clamped below (C++ sets jerk based on t > 0)
@@ -1229,29 +1269,36 @@ function check!(buf::ProfileBuffer{T}, control_signs::ControlSigns, limits::Reac
         buf.p[i+1] = pi + ti * (vi + ti * (ai / 2 + ti * ji / 6))
 
         # Reference implementation (profile.hpp lines 225-246):
-        # For velocity-limited profiles, explicitly set a[4] = 0 after phase 3
-        # This is done ALWAYS for velocity profiles (not inside set_limits block)
-        if limits in (LIMIT_ACC0_ACC1_VEL, LIMIT_ACC0_VEL, LIMIT_ACC1_VEL, LIMIT_VEL) && i == 3
+        # For profiles whose acceleration returns to zero after phase 3
+        # (all velocity-limited classes and ACC0_ACC1), explicitly set a[4] = 0.
+        # This is done ALWAYS (not inside the set_limits block)
+        if limits in (LIMIT_ACC0_ACC1_VEL, LIMIT_ACC0_ACC1, LIMIT_ACC0_VEL, LIMIT_ACC1_VEL, LIMIT_VEL) && i == 3
             buf.a[4] = zero(T)
         end
 
-        # For ACC1 profiles, set a[4] = aMin (C++ uses set_limits=true for ACC1)
-        if limits == LIMIT_ACC1 && i == 3
-            buf.a[4] = aMin
-        end
+        # C++ gates these snaps behind the set_limits template flag: only the
+        # step-1 ACC1/ACC0_ACC1 call sites request them; step 2 never does,
+        # where snapping would corrupt profiles whose plateau is not at the limit
+        if set_limits
+            if limits == LIMIT_ACC1 && i == 3
+                buf.a[4] = aMin
+            end
 
-        # For ACC0_ACC1 profiles, set a[2] = aMax and a[6] = aMin
-        if limits == LIMIT_ACC0_ACC1
-            if i == 1
-                buf.a[2] = aMax
-            elseif i == 5
-                buf.a[6] = aMin
+            if limits == LIMIT_ACC0_ACC1
+                if i == 1
+                    buf.a[2] = aMax
+                elseif i == 5
+                    buf.a[6] = aMin
+                end
             end
         end
 
         cumtime += ti
         buf.t_sum[i] = cumtime
     end
+
+    # Reject numerically absurd durations (C++ profile.hpp: t_sum.back() > t_max)
+    buf.t_sum[7] > T_MAX && return false
 
     # Check final state
     abs(buf.p[8] - pf) > P_PRECISION && return false
@@ -1454,7 +1501,7 @@ If `vpc` is `nothing`, returns after finding the first valid profile (for time-o
 function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
                        jMax, vMax, vMin, aMax, aMin;
                        vpc::Union{ValidProfileCollection{T}, Nothing}=nothing,
-                       brake_duration::T=zero(T), brake::Union{RuckigProfile{T}, Nothing}=nothing) where T
+                       brake_duration::T=zero(T), brake::Union{BrakeProfile{T}, Nothing}=nothing) where T
     # Pre-compute common terms
     jMax_jMax = jMax^2
     a0_a0 = a0^2
@@ -1466,8 +1513,6 @@ function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
     v0_v0 = v0^2
     vf_vf = vf^2
     pd = pf - p0
-
-    found_any = false
 
     # Strategy 1: ACC0_ACC1_VEL (reach aMax, vMax, aMin)
     begin
@@ -1488,11 +1533,10 @@ function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
                                 jMax*(aMax*vf_vf - aMin*v0_v0))) / (24*aMax*aMin*jMax_jMax*vMax)
 
         if check!(buf, UDDU, LIMIT_ACC0_ACC1_VEL, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            if vpc === nothing
-                return true
-            end
-            add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
-            found_any = true
+            # C++ time_all_vel returns after the FIRST successful profile even in
+            # collection mode - the velocity family contributes at most one profile
+            vpc === nothing || add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
+            return true
         end
     end
 
@@ -1513,11 +1557,10 @@ function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
         buf.t[7] = buf.t[5] + af / jMax
 
         if check!(buf, UDDU, LIMIT_ACC1_VEL, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            if vpc === nothing
-                return true
-            end
-            add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
-            found_any = true
+            # C++ time_all_vel returns after the FIRST successful profile even in
+            # collection mode - the velocity family contributes at most one profile
+            vpc === nothing || add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
+            return true
         end
     end
 
@@ -1539,11 +1582,10 @@ function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
         buf.t[7] = t_acc1 + af/jMax
 
         if check!(buf, UDDU, LIMIT_ACC0_VEL, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            if vpc === nothing
-                return true
-            end
-            add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
-            found_any = true
+            # C++ time_all_vel returns after the FIRST successful profile even in
+            # collection mode - the velocity family contributes at most one profile
+            vpc === nothing || add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
+            return true
         end
     end
 
@@ -1564,15 +1606,14 @@ function time_all_vel!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
                        (v0/vMax + 1.0)*t_acc0 - (vf/vMax + 1.0)*t_acc1 + pd/vMax
 
         if check!(buf, UDDU, LIMIT_VEL, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            if vpc === nothing
-                return true
-            end
-            add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
-            found_any = true
+            # C++ time_all_vel returns after the FIRST successful profile even in
+            # collection mode - the velocity family contributes at most one profile
+            vpc === nothing || add_profile!(vpc, RuckigProfile(buf, pf, vf, af; brake_duration, brake))
+            return true
         end
     end
 
-    return found_any
+    return false
 end
 
 """
@@ -1584,7 +1625,7 @@ If `vpc` is `nothing`, returns the shortest valid profile found (for time-optima
 function time_acc0_acc1!(buf::ProfileBuffer{T}, candidate::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
                          jMax, vMax, vMin, aMax, aMin;
                          vpc::Union{ValidProfileCollection{T}, Nothing}=nothing,
-                         brake_duration::T=zero(T), brake::Union{RuckigProfile{T}, Nothing}=nothing) where T
+                         brake_duration::T=zero(T), brake::Union{BrakeProfile{T}, Nothing}=nothing) where T
     # Pre-compute common terms
     jMax_jMax = jMax^2
     a0_a0 = a0^2
@@ -1631,7 +1672,7 @@ function time_acc0_acc1!(buf::ProfileBuffer{T}, candidate::ProfileBuffer{T}, p0,
         candidate.t[6] = h3 + h1_sign * h1 / aMin
         candidate.t[7] = candidate.t[5] + af / jMax
 
-        if check!(candidate, UDDU, LIMIT_ACC0_ACC1, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
+        if check!(candidate, UDDU, LIMIT_ACC0_ACC1, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af, true)
             if vpc !== nothing
                 # Collecting mode: add all valid profiles
                 add_profile!(vpc, RuckigProfile(candidate, pf, vf, af; brake_duration, brake))
@@ -1663,7 +1704,7 @@ function time_all_none_acc0_acc1!(roots::Roots, buf::ProfileBuffer{T}, candidate
                                   p0, v0, a0, pf, vf, af,
                                   jMax, vMax, vMin, aMax, aMin;
                                   vpc::Union{ValidProfileCollection{T}, Nothing}=nothing,
-                                  brake_duration::T=zero(T), brake::Union{RuckigProfile{T}, Nothing}=nothing) where T
+                                  brake_duration::T=zero(T), brake::Union{BrakeProfile{T}, Nothing}=nothing) where T
     # Pre-compute common terms
     jMax_jMax = jMax^2
     a0_a0 = a0^2
@@ -1832,7 +1873,7 @@ function time_all_none_acc0_acc1!(roots::Roots, buf::ProfileBuffer{T}, candidate
         candidate.t[6] = h3_acc1 - (2*a0 + jMax*t)*t/aMin
         candidate.t[7] = (af - aMin)/jMax
 
-        if check!(candidate, UDDU, LIMIT_ACC1, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
+        if check!(candidate, UDDU, LIMIT_ACC1, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af, true)
             if vpc !== nothing
                 # Collecting mode: add all valid profiles
                 add_profile!(vpc, RuckigProfile(candidate, pf, vf, af; brake_duration, brake))
@@ -1939,36 +1980,29 @@ function time_acc0_two_step!(buf::ProfileBuffer{T}, p0, v0, a0, pf, vf, af,
         return true
     end
 
-    # Strategy 3: Three-step with polynomial solution
-    h0 = 3*(af_af - a0_a0 + 2*jMax*(v0 + vf))
-    if abs(h0) > EPS
+    # Strategy 3: Three-step - Removed aMax (position_third_step1.cpp lines 333-350)
+    begin
+        h0 = 3*(af_af - a0_a0 + 2*jMax*(v0 + vf))
         h2 = a0_p3 + 2*af_p3 + 6*jMax_jMax*pd + 6*(af - a0)*jMax*vf - 3*a0*af_af
+        h1_rad = 2*(2*h2^2 + h0*(a0_p4 - 6*a0_a0*(af_af + 2*jMax*vf) +
+                    8*a0*(af_p3 + 3*jMax_jMax*pd + 3*af*jMax*vf) -
+                    3*(af_p4 + 4*af_af*jMax*vf + 4*jMax_jMax*(vf^2 - v0^2))))
 
-        # Solve for intermediate acceleration
-        # The polynomial is complex; use a simplified approach
-        h1_sq = 2*(2*h2^2 + h0*(a0_p4 - 6*a0_a0*(af_af + 2*jMax*vf) +
-                8*a0_p3*af + 3*af_p4 - 6*af_af*jMax*vf - 12*jMax_jMax*(vf^2 - pd*(vf - v0))))
+        # C++ takes sqrt of a possibly-negative radicand and lets the NaN fail the
+        # check; Julia sqrt would throw, so skip the strategy explicitly instead
+        if h1_rad >= 0
+            h1 = sqrt(h1_rad) * abs(jMax) / jMax
 
-        if h1_sq >= 0
-            for h1_sign in (1, -1)
-                h1 = h1_sign * sqrt(h1_sq)
-                a_peak = (a0_a0 + af_af + 2*jMax*(vf - v0) + h1/h0) / 2
+            buf.t[1] = (4*af_p3 + 2*a0_p3 - 6*a0*af_af + 12*jMax_jMax*pd + 12*(af - a0)*jMax*vf + h1)/(2*jMax*h0)
+            buf.t[2] = -h1/(jMax*h0)
+            buf.t[3] = (-4*a0_p3 - 2*af_p3 + 6*a0_a0*af + 12*jMax_jMax*pd - 12*(af - a0)*jMax*v0 + h1)/(2*jMax*h0)
+            buf.t[4] = 0
+            buf.t[5] = 0
+            buf.t[6] = 0
+            buf.t[7] = 0
 
-                if a_peak > 0
-                    a_peak = sqrt(a_peak)
-
-                    buf.t[1] = (a_peak - a0)/jMax
-                    buf.t[2] = 0
-                    buf.t[3] = (a_peak - af)/jMax
-                    buf.t[4] = 0
-                    buf.t[5] = 0
-                    buf.t[6] = 0
-                    buf.t[7] = 0
-
-                    if check!(buf, UDDU, LIMIT_ACC0, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-                        return true
-                    end
-                end
+            if check!(buf, UDDU, LIMIT_ACC0, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
+                return true
             end
         end
     end
@@ -2245,8 +2279,10 @@ function calculate_trajectory(lim::JerkLimiter{T}; pf, p0=zero(T), v0=zero(T), a
 
     # Zero-limits special case: jMax=0, aMax=0, or aMin=0
     # C++ Reference: position_third_step1.cpp lines 511-525
+    # C++ passes the UNSWAPPED limits here; the profile checks are not
+    # direction-aware, so swapped limits reject every pd < 0 trajectory
     if jmax == 0 || amax == 0 || amin == 0
-        if time_all_single_step!(buf, p0_eff, v0_eff, a0_eff, pf, vf, af, jMax1, vMax1, vMin1, aMax1, aMin1)
+        if time_all_single_step!(buf, p0_eff, v0_eff, a0_eff, pf, vf, af, jmax, vmax, vmin, amax, amin)
             return RuckigProfile(buf, pf, vf, af; brake_duration, brake=brake_copy)
         end
         # Build error message with explicit concatenation to avoid vararg type instability (JuliaC compatibility)
@@ -2422,7 +2458,7 @@ function calculate_trajectory_with_block(lim::JerkLimiter{T}; pf, p0=zero(T), v0
     get_position_brake_trajectory!(brake, v0, a0, vmax, vmin, amax, amin, jmax)
     ps, vs, as = finalize_brake!(brake, p0, v0, a0)
     brake_duration = brake.duration
-    brake_copy = brake_duration > 0 ? deepcopy(brake) : nothing
+    brake_copy = brake_duration > 0 ? copy(brake) : nothing
 
     # Use post-brake state as effective initial state
     p0_eff, v0_eff, a0_eff = ps, vs, as
@@ -2438,9 +2474,18 @@ function calculate_trajectory_with_block(lim::JerkLimiter{T}; pf, p0=zero(T), v0
     end
 
     # Zero-limits special case: jMax=0, aMax=0, or aMin=0
+    # C++ passes the UNSWAPPED limits here (see comment in calculate_trajectory)
     if jmax == 0 || amax == 0 || amin == 0
-        if time_all_single_step!(buf, p0_eff, v0_eff, a0_eff, pf, vf, af, jMax1, vMax1, vMin1, aMax1, aMin1)
-            return Block(RuckigProfile(buf, pf, vf, af; brake_duration, brake=brake_copy))
+        if time_all_single_step!(buf, p0_eff, v0_eff, a0_eff, pf, vf, af, jmax, vmax, vmin, amax, amin)
+            profile = RuckigProfile(buf, pf, vf, af; brake_duration, brake=brake_copy)
+            # C++ position_third_step1.cpp:497-499: with a moving initial state
+            # only the exact t_min duration is feasible - block everything longer
+            if abs(v0_eff) > EPS || abs(a0_eff) > EPS
+                t_min_zl = duration(profile)
+                return Block{Float64}(profile, t_min_zl,
+                    BlockInterval{Float64}(t_min_zl, Inf, profile), nothing)
+            end
+            return Block(profile)
         end
         # Build error message with explicit concatenation to avoid vararg type instability (JuliaC compatibility)
         msg = "No valid trajectory found for zero-limits case from (" * string(p0) * ", " * string(v0) * ", " * string(a0) *
@@ -2630,20 +2675,23 @@ function calculate_waypoint_trajectory(lim::JerkLimiter, waypoints, Ts)
         # Sample at Ts intervals
         ps, vs, as, js, ts = evaluate_dt(profile, Ts)
 
-        # Shift times by offset and append
-        if i == 1
-            append!(all_ts, ts .+ t_offset)
-            append!(all_ps, ps)
-            append!(all_vs, vs)
-            append!(all_as, as)
-            append!(all_js, js)
-        else
-            # Skip first point to avoid duplicates at waypoint boundaries
+        # Shift times by offset and append. The first sample of a segment (at
+        # exactly t_offset) is a duplicate only when the previous segment's last
+        # sample landed on its full duration, i.e. the duration was a multiple of
+        # Ts - otherwise the exact waypoint sample must be kept
+        skip_first = !isempty(all_ts) && abs(all_ts[end] - t_offset) <= Ts * 1e-9
+        if skip_first
             append!(all_ts, (ts .+ t_offset)[2:end])
             append!(all_ps, ps[2:end])
             append!(all_vs, vs[2:end])
             append!(all_as, as[2:end])
             append!(all_js, js[2:end])
+        else
+            append!(all_ts, ts .+ t_offset)
+            append!(all_ps, ps)
+            append!(all_vs, vs)
+            append!(all_as, as)
+            append!(all_js, js)
         end
 
         t_offset += duration(profile)
@@ -2714,19 +2762,22 @@ function calculate_waypoint_trajectory(lims::AbstractVector{<:JerkLimiter{T}}, w
         # Sample at Ts intervals
         ps, vs, as, js, ts = evaluate_dt(profiles, Ts)
 
-        # Shift times by offset and append
-        if i == 1
-            append!(all_ts, ts .+ t_offset)
-            for k in axes(ps, 1)
+        # Shift times by offset and append. The first sample of a segment is a
+        # duplicate only when the previous segment's last sample landed exactly
+        # on its full duration (duration a multiple of Ts) - otherwise the exact
+        # waypoint sample must be kept
+        skip_first = !isempty(all_ts) && abs(all_ts[end] - t_offset) <= Ts * 1e-9
+        if skip_first
+            append!(all_ts, (ts .+ t_offset)[2:end])
+            for k in 2:size(ps, 1)
                 push!(all_ps, ps[k, :])
                 push!(all_vs, vs[k, :])
                 push!(all_as, as[k, :])
                 push!(all_js, js[k, :])
             end
         else
-            # Skip first point to avoid duplicates at waypoint boundaries
-            append!(all_ts, (ts .+ t_offset)[2:end])
-            for k in 2:size(ps, 1)
+            append!(all_ts, ts .+ t_offset)
+            for k in axes(ps, 1)
                 push!(all_ps, ps[k, :])
                 push!(all_vs, vs[k, :])
                 push!(all_as, as[k, :])
@@ -2827,16 +2878,10 @@ function check_step2!(buf::ProfileBuffer{T}, control_signs::ControlSigns, limits
     # Check jerk limit if provided
     abs(jf) > jMax_limit + EPS && return false
 
-    # Use existing check function
-    result = check!(buf, control_signs, limits, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-    if !result
-        return false
-    end
-
-    # Verify total duration matches tf
-    abs(buf.t_sum[7] - tf) > T_PRECISION && return false
-
-    return true
+    # No duration check against tf: C++ check_with_timing has it commented out
+    # ("Time doesn't need to be checked as every profile has a: tf - ... equation");
+    # an absolute gate would spuriously reject valid profiles for large tf
+    return check!(buf, control_signs, limits, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
 end
 
 """
@@ -2861,19 +2906,22 @@ function time_acc0_acc1_vel_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
                 4*af_af + 2*a0_a0 + (4*af + aMax - aMin)*(aMax - aMin) +
                 4*jMax*(aMin - aMax + jMax*tf - 2*af)*tf
 
-        h1_sq >= 0 || return false
-        h1 = sqrt(h1_sq) * sign(jMax)
+        # C++ sqrt(negative) yields NaN and merely fails this candidate's check;
+        # skip only this UDDU attempt - the UDUD profile below must still be tried
+        if h1_sq >= 0
+            h1 = sqrt(h1_sq) * sign(jMax)
 
-        buf.t[1] = (-a0 + aMax)/jMax
-        buf.t[2] = (-(af_af - a0_a0 + 2*aMax^2 + aMin*(aMin - 2*ad - 3*aMax) + 2*jMax*(aMin*tf - vd)) + aMin*h1)/(2*(aMax - aMin)*jMax)
-        buf.t[3] = aMax/jMax
-        buf.t[4] = (aMin - aMax + h1)/(2*jMax)
-        buf.t[5] = -aMin/jMax
-        buf.t[6] = tf - (buf.t[1] + buf.t[2] + buf.t[3] + buf.t[4] + 2*buf.t[5] + af/jMax)
-        buf.t[7] = buf.t[5] + af/jMax
+            buf.t[1] = (-a0 + aMax)/jMax
+            buf.t[2] = (-(af_af - a0_a0 + 2*aMax^2 + aMin*(aMin - 2*ad - 3*aMax) + 2*jMax*(aMin*tf - vd)) + aMin*h1)/(2*(aMax - aMin)*jMax)
+            buf.t[3] = aMax/jMax
+            buf.t[4] = (aMin - aMax + h1)/(2*jMax)
+            buf.t[5] = -aMin/jMax
+            buf.t[6] = tf - (buf.t[1] + buf.t[2] + buf.t[3] + buf.t[4] + 2*buf.t[5] + af/jMax)
+            buf.t[7] = buf.t[5] + af/jMax
 
-        if check_step2!(buf, UDDU, LIMIT_ACC0_ACC1_VEL, tf, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            return true
+            if check_step2!(buf, UDDU, LIMIT_ACC0_ACC1_VEL, tf, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
+                return true
+            end
         end
     end
 
@@ -2933,7 +2981,6 @@ function time_acc1_vel_step2!(roots::Roots, buf::ProfileBuffer{T}, pc::Step2PreC
         # Newton refinement
         if abs(a0 + jMax*t) > 16*EPS
             h0 = jMax*t*t
-            h1 = -((a0_a0 + af_af)/2 + jMax*(-vd + 2*a0*t + h0))/aMin
             orig = -pd + (3*(a0_p4 + af_p4) - 8*af_p3*aMin - 4*a0_p3*aMin +
                    6*af_af*(aMin^2 + 2*jMax*(h0 - vd)) +
                    6*a0_a0*(af_af - 2*af*aMin + aMin^2 + 2*aMin*jMax*(-2*t + tf) + 2*jMax*(5*h0 - vd)) +
@@ -3122,9 +3169,9 @@ function time_acc0_acc1_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
         buf.t[6] = tf - (2*buf.t[1] + buf.t[2] + 2*buf.t[5])
         buf.t[7] = buf.t[5]
 
-        if check_step2!(buf, UDDU, LIMIT_ACC0_ACC1, tf, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af, abs(jMax))
-            return true
-        end
+        # C++ returns the simple-case check result directly and never tries the
+        # general case for zero boundary accelerations
+        return check_step2!(buf, UDDU, LIMIT_ACC0_ACC1, tf, jf, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af, abs(jMax))
     end
 
     # UDDU general case
@@ -3200,11 +3247,11 @@ function time_acc0_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
           3*jMax*(jMax*(-2*pd + aMax*tf_tf + 2*tf*v0) + aMax*(aMax*tf - 2*vd)) +
           3*af*(aMax^2 + 2*aMax*jMax*tf - 2*jMax*vd)
     h0_sq = 4*h0b^2 - 18*h0a^3
-    if h0_sq >= 0
+    # Degenerate h1: C++ divides (giving Inf/NaN), the check fails, and the
+    # NEXT solution block below is still tried - skip only this block
+    if h0_sq >= 0 && abs(3*jMax*h0a) >= EPS
         h0 = abs(jMax) * sqrt(h0_sq)
         h1 = 3*jMax*h0a
-
-        abs(h1) < EPS && return false
 
         buf.t[1] = (-a0 + aMax)/jMax
         buf.t[2] = (-a0_p3 + af_p3 + af_af*(-6*aMax + 3*jMax*tf) +
@@ -3229,11 +3276,9 @@ function time_acc0_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
           3*a0_a0*(af - 2*aMax + jMax*tf) - 6*jMax_jMax*g1 +
           6*(af - aMax)*jMax*vd - 3*aMax*jMax_jMax*tf_tf
     h0_sq = 4*h0a^2 - 18*h0b^3
-    if h0_sq >= 0
+    if h0_sq >= 0 && abs(6*jMax*h0b) >= EPS
         h1 = (jMax > 0 ? 1 : -1) * sqrt(h0_sq)
         h2 = 6*jMax*h0b
-
-        abs(h2) < EPS && return false
 
         buf.t[1] = (-a0 + aMax)/jMax
         buf.t[2] = ad/jMax - 2*buf.t[1] - (2*h0a - h1)/h2 + tf
@@ -3270,11 +3315,11 @@ function time_acc1_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
     if h0_sq >= 0
         h0 = sqrt(h0_sq)/jMax
         h1_sq = (a0_a0 + af_af - 2*a0*af - 2*ad*jMax*tf + 2*h0)/jMax_jMax + tf_tf
-        if h1_sq >= 0
+        # Degenerate denominator: C++ divides (Inf/NaN), the check fails, and the
+        # remaining solution blocks are still tried - skip only this block
+        denom = 2*jMax*(-ad + jMax*tf)
+        if h1_sq >= 0 && abs(denom) >= EPS
             h1 = sqrt(h1_sq)
-
-            denom = 2*jMax*(-ad + jMax*tf)
-            abs(denom) < EPS && return false
 
             buf.t[1] = -(a0_a0 + af_af + 2*a0*(jMax*tf - af) - 2*jMax*vd + h0)/denom
             buf.t[2] = 0
@@ -3298,11 +3343,9 @@ function time_acc1_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
     if h0_sq >= 0
         h0 = sqrt(h0_sq)/jMax
         h1_sq = (a0_a0 + af_af - 2*a0*af + 2*ad*jMax*tf + 2*h0)/jMax_jMax + tf_tf
-        if h1_sq >= 0
+        denom = 2*jMax*(ad + jMax*tf)
+        if h1_sq >= 0 && abs(denom) >= EPS
             h1 = sqrt(h1_sq)
-
-            denom = 2*jMax*(ad + jMax*tf)
-            abs(denom) < EPS && return false
 
             buf.t[1] = 0
             buf.t[2] = 0
@@ -3329,26 +3372,24 @@ function time_acc1_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
           4*a0*(af_p3 - 3*af*aMin*(-aMin - 2*jMax*tf) + 3*af_af*(-aMin - jMax*tf) +
                 3*jMax*(-aMin^2*tf + jMax*(-2*pd - aMin*tf_tf + 2*tf*vf)))
     h0_sq = 4*h0a^2 - 6*h0b*h0c
-    if h0_sq >= 0
+    if h0_sq >= 0 && abs(6*jMax*h0b) >= EPS
         h1 = (jMax > 0 ? 1 : -1) * sqrt(h0_sq)
         h2 = 6*jMax*h0b
 
-        abs(h2) < EPS && return false
+        t3 = (2*h0a + h1)/h2
+        denom = 2*jMax*(a0 - aMin - jMax*t3)
+        if abs(denom) >= EPS
+            buf.t[1] = 0
+            buf.t[2] = 0
+            buf.t[3] = t3
+            buf.t[4] = -(a0_a0 + af_af - 2*(a0 + af)*aMin + 2*(aMin^2 + aMin*jMax*tf - jMax*vd))/denom
+            buf.t[5] = (a0 - aMin)/jMax - t3
+            buf.t[6] = tf - (buf.t[3] + buf.t[4] + buf.t[5] + (af - aMin)/jMax)
+            buf.t[7] = (af - aMin)/jMax
 
-        buf.t[1] = 0
-        buf.t[2] = 0
-        buf.t[3] = (2*h0a + h1)/h2
-
-        denom = 2*jMax*(a0 - aMin - jMax*buf.t[3])
-        abs(denom) < EPS && return false
-
-        buf.t[4] = -(a0_a0 + af_af - 2*(a0 + af)*aMin + 2*(aMin^2 + aMin*jMax*tf - jMax*vd))/denom
-        buf.t[5] = (a0 - aMin)/jMax - buf.t[3]
-        buf.t[6] = tf - (buf.t[3] + buf.t[4] + buf.t[5] + (af - aMin)/jMax)
-        buf.t[7] = (af - aMin)/jMax
-
-        if check_step2!(buf, UDDU, LIMIT_ACC1, tf, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
-            return true
+            if check_step2!(buf, UDDU, LIMIT_ACC1, tf, jMax, vMax, vMin, aMax, aMin, p0, v0, a0, pf, vf, af)
+                return true
+            end
         end
     end
 
@@ -3361,11 +3402,9 @@ function time_acc1_step2!(buf::ProfileBuffer{T}, pc::Step2PreComputed,
           4*a0*(af_p3 + 3*af*aMax*(aMax - 2*jMax*tf) - 3*af_af*(aMax - jMax*tf) +
                 3*jMax*(aMax^2*tf + jMax*(-2*pd - aMax*tf_tf + 2*tf*vf)))
     h0_sq = 4*h0a^2 - 6*h0b*h0c
-    if h0_sq >= 0
+    if h0_sq >= 0 && abs(6*jMax*h0b) >= EPS
         h1 = (jMax > 0 ? 1 : -1) * sqrt(h0_sq)
         h2 = 6*jMax*h0b
-
-        abs(h2) < EPS && return false
 
         buf.t[1] = 0
         buf.t[2] = 0
@@ -3816,18 +3855,21 @@ function time_vel_step2!(roots::Roots, buf::ProfileBuffer{T}, pc::Step2PreComput
                      72*jMax_jMax*jMax*(jMax*g1*g1 + vd_vd*vd + 2*af*g1*vd) - 6*af_p4*jMax*vd +
                      36*af_af*jMax_jMax*vd_vd + 9*a0_p4*p1 + 3*a0_a0*ph2)/(144*jMax_jMax*jMax_jMax*ph4)
 
-        # Solve quintic using quartic derivative to find intervals
-        deriv_0 = 5.0
-        deriv_1 = 4*polynom_0
-        deriv_2 = 3*polynom_1
-        deriv_3 = 2*polynom_2
-        deriv_4 = polynom_3
+        # Solve quintic using quartic derivative to find intervals.
+        # C++ uses the MONIC derivative chain (poly_monic_derivative): deriv = P'/5,
+        # dderiv = P''/5 - the Newton trigger and the double-root tolerance below
+        # are calibrated against these normalized values
+        deriv_0 = 1.0
+        deriv_1 = 4*polynom_0/5
+        deriv_2 = 3*polynom_1/5
+        deriv_3 = 2*polynom_2/5
+        deriv_4 = polynom_3/5
 
-        # Second derivative coefficients for tolerance check
-        dderiv_0 = 20.0
-        dderiv_1 = 12*polynom_0
-        dderiv_2 = 6*polynom_1
-        dderiv_3 = 2*polynom_2
+        # Second derivative coefficients (derivative of the monic deriv): P''/5
+        dderiv_0 = 4.0
+        dderiv_1 = 3*deriv_1
+        dderiv_2 = 2*deriv_2
+        dderiv_3 = deriv_3
 
         ROOTS_TOL = 1e-14
 
@@ -3912,8 +3954,9 @@ function time_vel_step2!(roots::Roots, buf::ProfileBuffer{T}, pc::Step2PreComput
     end
 
     @label udud_general
-    # Profile UDUD - general case with 6th order polynomial
-    if !(abs(v0) < EPS && abs(a0) < EPS && abs(vf) < EPS && abs(af) < EPS)
+    # Profile UDUD - general case with 6th order polynomial.
+    # C++ runs this block unconditionally, also for all-zero boundary states
+    begin
         ph1 = af_af - 2*jMax*(2*af*tf + jMax*tf_tf - 3*vd)
         ph2 = af_p3 - 3*jMax_jMax*g1 + 3*af*jMax*vd
         ph3 = 2*jMax*tf*g1 + 3*vd_vd
@@ -3930,20 +3973,21 @@ function time_vel_step2!(roots::Roots, buf::ProfileBuffer{T}, pc::Step2PreComput
                      72*jMax_jMax*jMax*(jMax*g1*g1 - vd_vd*vd - 2*af*g1*vd) - 6*af_p4*jMax*vd -
                      36*af_af*jMax_jMax*vd_vd + 8*a0_p3*ph2 + 3*a0_a0*ph4)/(144*jMax_jMax*jMax_jMax*jMax_jMax)
 
-        # Solve using quintic derivative to find intervals
-        deriv_0 = 6.0
-        deriv_1 = 5*polynom_0
-        deriv_2 = 4*polynom_1
-        deriv_3 = 3*polynom_2
-        deriv_4 = 2*polynom_3
-        deriv_5 = polynom_4
+        # Solve using quintic derivative to find intervals.
+        # Monic derivative chain matching C++: deriv = P'/6, dderiv = P''/30
+        deriv_0 = 1.0
+        deriv_1 = 5*polynom_0/6
+        deriv_2 = 4*polynom_1/6
+        deriv_3 = 3*polynom_2/6
+        deriv_4 = 2*polynom_3/6
+        deriv_5 = polynom_4/6
 
-        # Use quartic solution on 4th derivative to find extrema
-        dderiv_0 = 30.0
-        dderiv_1 = 20*polynom_0
-        dderiv_2 = 12*polynom_1
-        dderiv_3 = 6*polynom_2
-        dderiv_4 = 2*polynom_3
+        # Use quartic solution on the second monic derivative to find extrema
+        dderiv_0 = 1.0
+        dderiv_1 = 4*deriv_1/5
+        dderiv_2 = 3*deriv_2/5
+        dderiv_3 = 2*deriv_3/5
+        dderiv_4 = deriv_4/5
 
         dd_tz_current = tz_min
         intervals = NTuple{2,T}[]
@@ -3951,6 +3995,13 @@ function time_vel_step2!(roots::Roots, buf::ProfileBuffer{T}, pc::Step2PreComput
         for tz in solve_quartic_real!(roots, dderiv_0, dderiv_1, dderiv_2, dderiv_3, dderiv_4)
             tz >= tz_max && continue
             tz <= dd_tz_current && continue  # Skip extrema that would create backwards intervals
+
+            # Newton refinement of the dderiv extremum (C++ does this before the sign test)
+            dd_orig = dderiv_4 + tz*(dderiv_3 + tz*(dderiv_2 + tz*(dderiv_1 + tz*dderiv_0)))
+            if abs(dd_orig) > 1e-14
+                ddd_val = dderiv_3 + tz*(2*dderiv_2 + tz*(3*dderiv_1 + tz*4*dderiv_0))
+                abs(ddd_val) > EPS && (tz -= dd_orig / ddd_val)
+            end
 
             # Check sign change in 1st derivative
             val_current = deriv_5 + dd_tz_current*(deriv_4 + dd_tz_current*(deriv_3 + dd_tz_current*(deriv_2 + dd_tz_current*(deriv_1 + dd_tz_current*deriv_0))))
@@ -4325,7 +4376,9 @@ function get_first_state_at_position(profile::RuckigProfile{T}, pt::Real; time_a
             disc = v^2 - 2*a*(p - pt)
             if disc >= 0
                 disc_sqrt = sqrt(disc)
-                for t_root in ((-v - disc_sqrt) / a, (-v + disc_sqrt) / a)
+                # minmax: iterate in ascending time order regardless of sign(a),
+                # so the FIRST crossing is returned
+                for t_root in minmax((-v - disc_sqrt) / a, (-v + disc_sqrt) / a)
                     if 0 < t_root <= profile.t[i] && (time_after - t_cum) <= t_root
                         return (true, t_root + t_cum)
                     end
@@ -4405,13 +4458,16 @@ function solve_cubic_real(a, b, c, d)
         end
     else
         # Three distinct real roots
-        theta = acos(R / sqrt(-Q^3))
+        theta = acos(clamp(R / sqrt(-Q^3), -1.0, 1.0))
         sqrt_neg_Q = sqrt(-Q)
         push!(roots, 2*sqrt_neg_Q*cos(theta/3) - p/3)
         push!(roots, 2*sqrt_neg_Q*cos((theta + 2π)/3) - p/3)
         push!(roots, 2*sqrt_neg_Q*cos((theta + 4π)/3) - p/3)
     end
 
+    # Ascending order so that consumers scanning for the first crossing time
+    # find the earliest root (C++ roots::Set sorts on access)
+    sort!(roots)
     return roots
 end
 
@@ -4455,8 +4511,10 @@ function calculate_trajectory(lims::AbstractVector{<:JerkLimiter{T}};
     length(vf) == ndof || throw(ArgumentError("vf must have length $ndof"))
     length(af) == ndof || throw(ArgumentError("af must have length $ndof"))
 
-    # Step 1: Calculate minimum-time profile for each DOF with blocked intervals
-    blocks = Vector{Block{T}}(undef, ndof)
+    # Step 1: Calculate minimum-time profile for each DOF with blocked intervals.
+    # Profiles are always computed in Float64 (the limiter work buffers are Float64),
+    # so the element type here is Float64 regardless of the limiter value type T
+    blocks = Vector{Block{Float64}}(undef, ndof)
     for i in 1:ndof
         blocks[i] = calculate_trajectory_with_block(lims[i];
             p0=p0[i], v0=v0[i], a0=a0[i],
@@ -4475,7 +4533,6 @@ function calculate_trajectory(lims::AbstractVector{<:JerkLimiter{T}};
         bi = blocks[i]
         push!(candidates, (bi.t_min, i, 0))
         if bi.a !== nothing
-            bi.a.right
             push!(candidates, (bi.a.right, i, 1))
         end
         if bi.b !== nothing
@@ -4525,21 +4582,28 @@ function calculate_trajectory(lims::AbstractVector{<:JerkLimiter{T}};
 
     for i in 1:ndof
         bi = blocks[i]
-        # Check if this DOF can use an existing profile (from Step 1 or blocked interval)
-        # Use 2*eps tolerance for numerical robustness (matching C++ line 480)
-        if abs(t_sync - bi.t_min) < 2 * T_PRECISION
+        # Check if this DOF can use an existing profile (from Step 1 or blocked interval).
+        # Block boundaries include the brake duration, so compare against t_sync directly.
+        # Use 2*eps tolerance for numerical robustness (C++ calculator_target.hpp:476)
+        if abs(t_sync - bi.t_min) < 2 * eps(Float64)
             profiles[i] = bi.p_min
-        elseif !isnothing(bi.a) && abs(t_sync - bi.a.right) < 2 * T_PRECISION
+        elseif !isnothing(bi.a) && abs(t_sync - bi.a.right) < 2 * eps(Float64)
             profiles[i] = bi.a.profile
-        elseif !isnothing(bi.b) && abs(t_sync - bi.b.right) < 2 * T_PRECISION
+        elseif !isnothing(bi.b) && abs(t_sync - bi.b.right) < 2 * eps(Float64)
             profiles[i] = bi.b.profile
         else
-            # Need to recalculate for synchronized duration (Step 2)
+            # Need to recalculate for synchronized duration (Step 2).
+            # C++ solves step 2 from the post-brake state for the brake-excluded
+            # duration and keeps the brake pre-trajectory on the profile
+            pm = bi.p_min
+            t_profile = t_sync - pm.brake_duration
+            p0_eff, v0_eff, a0_eff = pm.p[1], pm.v[1], pm.a[1]
+
             buf = lims[i].buffer
             clear!(buf)
 
-            success = calculate_profile_step2!(lims[i].roots, buf, t_sync,
-                p0[i], v0[i], a0[i], pf[i], vf[i], af[i],
+            success = calculate_profile_step2!(lims[i].roots, buf, t_profile,
+                p0_eff, v0_eff, a0_eff, pf[i], vf[i], af[i],
                 lims[i].jmax, lims[i].vmax, lims[i].vmin,
                 lims[i].amax, lims[i].amin)
 
@@ -4547,7 +4611,8 @@ function calculate_trajectory(lims::AbstractVector{<:JerkLimiter{T}};
                 error("Failed to find synchronized profile for DOF $i at duration $t_sync. Blocks: $blocks, lims = $lims, p0 = $p0, v0 = $v0, a0 = $a0, pf = $pf, vf = $vf, af = $af")
             end
 
-            profiles[i] = RuckigProfile(buf, pf[i], vf[i], af[i])
+            profiles[i] = RuckigProfile(buf, pf[i], vf[i], af[i];
+                brake_duration=pm.brake_duration, brake=pm.brake)
         end
     end
 

--- a/src/ruckig_velocity.jl
+++ b/src/ruckig_velocity.jl
@@ -86,7 +86,21 @@ function check_for_velocity!(buf::ProfileBuffer{T}, v0, a0, vf, af, jf, aMax, aM
 
     buf.limits = limits
     buf.control_signs = control_signs
+    # C++ sets the direction per accepted profile from the sign of the aMax argument
+    buf.direction = aMax > 0 ? DIR_UP : DIR_DOWN
     return true
+end
+
+"""
+Shift the profile's position trace by the brake displacement `ps`: the main
+profile starts at the post-brake position (C++ brake.finalize updates p.p[0]
+in place, which the velocity interface then integrates from).
+"""
+function shift_position!(buf::ProfileBuffer, ps)
+    @inbounds for i in 1:8
+        buf.p[i] += ps
+    end
+    buf
 end
 
 """
@@ -342,8 +356,14 @@ function time_velocity_second_order_step1!(buf::ProfileBuffer{T}, v0, vf, aMax, 
         buf.p[i+1] = buf.p[i] + buf.t[i] * (buf.v[i] + buf.t[i] * buf.a[i] / 2)
     end
 
+    # Final-velocity and duration validation (C++ check_for_second_order_velocity);
+    # written NaN-safely: degenerate limits (aMax = 0) produce NaN/Inf times
+    abs(buf.v[8] - vf) <= V_PRECISION || return false
+    buf.t_sum[7] <= T_MAX || return false
+
     buf.limits = LIMIT_ACC0
     buf.control_signs = UDDU
+    buf.direction = af >= 0 ? DIR_UP : DIR_DOWN
     return true
 end
 
@@ -395,8 +415,12 @@ function time_velocity_second_order_step2!(buf::ProfileBuffer{T}, tf, v0, vf, aM
         buf.p[i+1] = buf.p[i] + buf.t[i] * (buf.v[i] + buf.t[i] * buf.a[i] / 2)
     end
 
+    abs(buf.v[8] - vf) <= V_PRECISION || return false
+    buf.t_sum[7] <= T_MAX || return false
+
     buf.limits = LIMIT_NONE
     buf.control_signs = UDDU
+    buf.direction = af >= 0 ? DIR_UP : DIR_DOWN
     return true
 end
 
@@ -427,9 +451,9 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
 
     # Compute velocity brake profile if initial acceleration is outside limits
     get_velocity_brake_trajectory!(brake, a0, amax, amin, jmax)
-    _, vs, as = finalize_brake!(brake, zero(T), v0, a0)
+    ps, vs, as = finalize_brake!(brake, zero(T), v0, a0)
     brake_duration = brake.duration
-    brake_copy = brake_duration > 0 ? deepcopy(brake) : nothing
+    brake_copy = brake_duration > 0 ? copy(brake) : nothing
 
     v0_eff, a0_eff = vs, as
     vd = vf - v0_eff
@@ -439,7 +463,8 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
         # Zero-limits special case
         if jmax == 0
             if time_all_single_step_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin)
-                return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+                shift_position!(buf, ps)
+                return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
             end
             error("Velocity trajectory not found for zero-jerk case")
         end
@@ -453,8 +478,8 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
                    time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
                    time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax) ||
                    time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax)
-                    buf.direction = vd >= 0 ? DIR_UP : DIR_DOWN
-                    return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+                    shift_position!(buf, ps)
+                    return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
                 end
             else
                 # Try DOWN direction first
@@ -462,19 +487,41 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
                    time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax) ||
                    time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
                    time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax)
-                    buf.direction = vd >= 0 ? DIR_UP : DIR_DOWN
-                    return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+                    shift_position!(buf, ps)
+                    return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
                 end
             end
         else
-            # af != 0: try all profiles (need to collect for potential blocked intervals)
-            # For simplicity in min-time case, just return first valid
-            if time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
-               time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax) ||
-               time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
-               time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax)
-                buf.direction = vd >= 0 ? DIR_UP : DIR_DOWN
-                return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+            # af != 0: several extremal profiles can be valid; C++ collects them all
+            # and Block picks the minimum duration. The full block machinery is not
+            # ported for the velocity interface, but the min-duration selection is
+            best = lim.candidate
+            best_duration = T(Inf)
+
+            if time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) && buf.t_sum[7] < best_duration
+                best_duration = buf.t_sum[7]
+                copy_buffer!(best, buf)
+            end
+            clear!(buf)
+            if time_none_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax) && buf.t_sum[7] < best_duration
+                best_duration = buf.t_sum[7]
+                copy_buffer!(best, buf)
+            end
+            clear!(buf)
+            if time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amax, amin, jmax) && buf.t_sum[7] < best_duration
+                best_duration = buf.t_sum[7]
+                copy_buffer!(best, buf)
+            end
+            clear!(buf)
+            if time_acc0_velocity!(buf, v0_eff, a0_eff, vf, af, amin, amax, -jmax) && buf.t_sum[7] < best_duration
+                best_duration = buf.t_sum[7]
+                copy_buffer!(best, buf)
+            end
+
+            if isfinite(best_duration)
+                copy_buffer!(buf, best)
+                shift_position!(buf, ps)
+                return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
             end
         end
 
@@ -491,8 +538,8 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
                time_none_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
                time_acc0_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amin, amax, -jmax) ||
                time_none_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amin, amax, -jmax)
-                buf.direction = DIR_UP
-                return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+                shift_position!(buf, ps)
+                return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
             end
         else
             # Try DOWN direction first
@@ -500,8 +547,8 @@ function calculate_velocity_trajectory(lim::JerkLimiter{T}; vf, v0=zero(T), a0=z
                time_none_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amin, amax, -jmax) ||
                time_acc0_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amax, amin, jmax) ||
                time_none_velocity_step2!(buf, tf_eff, v0_eff, a0_eff, vf, af, amax, amin, jmax)
-                buf.direction = DIR_DOWN
-                return RuckigProfile(buf, zero(T), vf, af; brake_duration, brake=brake_copy)
+                shift_position!(buf, ps)
+                return RuckigProfile(buf, buf.p[8], vf, af; brake_duration, brake=brake_copy)
             end
         end
 
@@ -528,13 +575,13 @@ function calculate_velocity_trajectory(lim::AccelerationLimiter{T}; vf, v0=zero(
     if isnothing(tf)
         # Time-optimal case
         if time_velocity_second_order_step1!(buf, v0, vf, amax, amin)
-            return RuckigProfile(buf, zero(T), vf, zero(T))
+            return RuckigProfile(buf, buf.p[8], vf, zero(T))
         end
         error("Second-order velocity trajectory not found (v0=$v0, vf=$vf)")
     else
         # Time-synchronized case
         if time_velocity_second_order_step2!(buf, tf, v0, vf, amax, amin)
-            return RuckigProfile(buf, zero(T), vf, zero(T))
+            return RuckigProfile(buf, buf.p[8], vf, zero(T))
         end
         error("Second-order velocity trajectory with duration $tf not found (v0=$v0, vf=$vf)")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,16 @@ X2, Ẋ2, Ẍ2 = limiter(X, Ẋ, Ẍ, R)
     include("test_ruckig.jl")
 end
 
+@testset "regression" begin
+    @info "Testing regressions for C++-alignment fixes"
+    include("test_regression.jl")
+end
+
+@testset "properties" begin
+    @info "Testing randomized properties"
+    include("test_properties.jl")
+end
+
 # JET tests must be run LAST - loading JET.jl may interfere with other tests
 # due to its extensive use of Julia's compiler internals
 @testset "JET static analysis" begin

--- a/test/test_properties.jl
+++ b/test/test_properties.jl
@@ -1,0 +1,455 @@
+# Randomized property-based tests for the Ruckig-style jerk-limited trajectory
+# generator. This file is include()d from runtests.jl inside a parent testset.
+#
+# Each sub-testset seeds the global RNG for reproducibility. Violations are
+# accumulated per property and asserted in aggregate; on failure, the exact
+# offending inputs are printed (repr round-trips Float64) as reproducers.
+
+using TrajectoryLimiters
+using Test
+using Random
+
+#=============================================================================
+ Helpers (prefixed _pt_ to avoid clashes with other included test files)
+=============================================================================#
+
+_pt_rand_in(rng, lo, hi) = lo + (hi - lo) * rand(rng)
+_pt_loguniform(rng, lo, hi) = exp(_pt_rand_in(rng, log(lo), log(hi)))
+
+"Random limiter with log-uniform limits; asymmetric vmin/amin half of the time."
+function _pt_rand_limiter(rng)
+    vmax = _pt_loguniform(rng, 0.05, 50.0)
+    amax = _pt_loguniform(rng, 0.05, 50.0)
+    jmax = _pt_loguniform(rng, 0.05, 50.0)
+    if rand(rng) < 0.5
+        vmin = -vmax * _pt_rand_in(rng, 0.3, 1.5)
+        amin = -amax * _pt_rand_in(rng, 0.3, 1.5)
+    else
+        vmin = -vmax
+        amin = -amax
+    end
+    JerkLimiter(; vmax, amax, jmax, vmin, amin)
+end
+
+"Value strictly outside [lo, hi] (up to 2.5x beyond the limit), random side."
+_pt_outside(rng, lo, hi) =
+    rand(rng) < 0.5 ? hi * _pt_rand_in(rng, 1.05, 2.5) : lo * _pt_rand_in(rng, 1.05, 2.5)
+
+"""
+Random target acceleration that is dynamically feasible for the target velocity
+`vf`. Ending at (vf, af) with af > 0 forces the velocity to dip to
+vf - af^2/(2 jmax) just before the final jerk ramp (and symmetrically toward
+vmax for af < 0), so |af| must satisfy af^2 <= 2 jmax (vf - vmin) resp.
+af^2 <= 2 jmax (vmax - vf). The C++ Ruckig reference rejects targets outside
+this set in input validation; this port throws for them. `frac` leaves a
+safety margin to the boundary.
+"""
+function _pt_rand_af(rng, lim, vf; frac)
+    (; vmax, vmin, amax, amin, jmax) = lim
+    hi = frac * min(amax, sqrt(2 * jmax * max(vf - vmin, 0.0)))
+    lo = -frac * min(-amin, sqrt(2 * jmax * max(vmax - vf, 0.0)))
+    return _pt_rand_in(rng, lo, hi)
+end
+
+"Reproducer string: limiter parameters merged with problem inputs, exact via repr."
+_pt_repro(lim; kw...) = string(merge(
+    (; vmax = lim.vmax, vmin = lim.vmin, amax = lim.amax, amin = lim.amin, jmax = lim.jmax),
+    values(kw)))
+
+"Closeness with atol 1e-6 + rtol 1e-9 (positions can have larger scale)."
+_pt_close(x, y) = abs(x - y) <= 1e-6 + 1e-9 * max(abs(x), abs(y))
+
+"""
+Unavoidable velocity excursion beyond the velocity limits from the initial
+state (v0, a0), in multiples of the velocity band width. Acceleration can only
+decay at rate jmax, so the velocity overshoots v0 by up to a0^2/(2 jmax) even
+under immediate maximal braking. A brake pre-trajectory handles such states,
+but when this ratio is large the post-brake velocity is still far outside the
+limits and the main-profile search operates at an extreme feasibility boundary.
+"""
+function _pt_excess_ratio(lim, v0, a0)
+    (; vmax, vmin, jmax) = lim
+    exc = a0 > 0 ? (v0 + a0^2 / (2jmax)) - vmax : vmin - (v0 - a0^2 / (2jmax))
+    exc = max(exc, v0 - vmax, vmin - v0, 0.0)
+    return exc / (vmax - vmin)
+end
+
+# FIXME(known solver limitation): calculate_trajectory can throw
+# "No valid trajectory found" for initial states whose unavoidable velocity
+# excursion exceeds the velocity band by more than roughly 20x
+# (_pt_excess_ratio > 20; e.g. a0 = 24.3 with jmax = 0.155 and vmax = 2.0).
+# A 20k-case probe found NO failures below ratio 20 and none without a brake
+# phase, while failures above that boundary are probabilistic (successes exist
+# up to ratio 7665). Example reproducer:
+#   JerkLimiter(; vmax=2.0259680650948524, vmin=-2.007782731708046,
+#               amax=43.56327529769432, amin=-18.600971789243044,
+#               jmax=0.15457607796292946)
+#   calculate_trajectory(lim; p0=9.893146566489744, v0=-0.7362226673099832,
+#       a0=24.34693412809056, pf=-3.1589588894504717, vf=0.8406854613874348,
+#       af=-0.4033399687373154)
+# Exceptions from cases above the threshold below are tracked separately and
+# only bounded loosely instead of being asserted to zero.
+const _PT_EXTREME_RATIO = 10.0
+
+"Print collected reproducers (capped) and return the violation count."
+function _pt_dump(name, fails; max_print = 20)
+    if !isempty(fails)
+        println("  [", name, "]: ", length(fails), " violation(s)")
+        for r in Iterators.take(fails, max_print)
+            println("    REPRODUCER: ", r)
+        end
+        length(fails) > max_print && println("    ... and ", length(fails) - max_print, " more")
+    end
+    return length(fails)
+end
+
+_pt_new_viol() = (; err = String[], final = String[], vlim = String[],
+    alim = String[], jerk = String[], trapz = String[])
+
+"Print known-issue reproducers (bounded, not asserted to zero); returns count."
+function _pt_dump_known(name, fails, n_class; max_print = 3)
+    if !isempty(fails)
+        println("  [KNOWN ISSUE, ", name, "]: ", length(fails), " of ", n_class,
+            " extreme cases (see FIXME at _PT_EXTREME_RATIO)")
+        for r in Iterators.take(fails, max_print)
+            println("    REPRODUCER: ", r)
+        end
+    end
+    return length(fails)
+end
+
+"""
+Check final state and sampled kinematics of `prof` against the limits of `lim`,
+pushing violation reproducers into the vectors of `viol`.
+
+- `pf === nothing` skips the final-position check (velocity interface).
+- Limits are only checked after the brake pre-trajectory, which may legally
+  exceed them. Note that a brake phase can be triggered even when (v0, a0) are
+  individually within limits: if v0 + a0^2/(2 jmax) is outside the velocity
+  limits, a velocity excursion beyond the limits is dynamically unavoidable.
+- Velocity check: matching the C++ reference brake semantics, the post-brake
+  velocity itself can still be outside the limits for extreme initial states
+  (the brake reserves exactly the jerk-limited recovery margin). The invariant
+  tested is therefore that the main profile never violates the velocity limits
+  by MORE than the post-brake state already does. For in-limit initial states
+  (post-brake velocity within limits) this reduces to a strict limit check.
+- `check_v = false` skips velocity-limit checks (the velocity interface does
+  not enforce vmax).
+- Acceleration is checked strictly against [amin, amax] after the brake.
+- Jerk is checked on all samples (brake profiles also use jmax).
+- `check_trapz` verifies trapezoid consistency of consecutive (p, v) samples,
+  which catches discontinuities in the evaluated trajectory.
+"""
+function _pt_check_profile!(viol, lim, prof, repro; vf, af, pf = nothing,
+        nsamples::Int, check_v::Bool = true, check_trapz::Bool = false)
+    (; vmax, vmin, amax, amin, jmax) = lim
+    Ttot = duration(prof)
+    if !isfinite(Ttot) || Ttot < 0
+        push!(viol.final, string(repro, " | invalid duration ", repr(Ttot)))
+        return
+    end
+
+    s = evaluate_at(prof, Ttot)
+    final_ok = (pf === nothing || _pt_close(s.p, pf)) && _pt_close(s.v, vf) && _pt_close(s.a, af)
+    final_ok || push!(viol.final, string(repro, " | final state ", s, " != target"))
+
+    Ttot > 0 || return
+    ts = range(0.0, Ttot, length = nsamples)
+    P, V, A, J = evaluate_at(prof, ts)
+
+    jworst = maximum(abs, J)
+    jworst <= jmax + 1e-9 ||
+        push!(viol.jerk, string(repro, " | max|j|=", repr(jworst), " > jmax"))
+
+    bd = prof.brake_duration
+    limit_start = bd + max(1e-9, 1e-9 * bd)
+    # Post-brake state: evaluate_at at t == brake_duration hits the main
+    # profile (initial state when there is no brake)
+    spb = evaluate_at(prof, bd)
+    vhi_allow = vmax + max(0.0, spb.v - vmax) + 1e-6 + 1e-9 * abs(spb.v)
+    vlo_allow = vmin - max(0.0, vmin - spb.v) - 1e-6 - 1e-9 * abs(spb.v)
+
+    vworst = -Inf
+    aworst = -Inf
+    for i in eachindex(ts)
+        ts[i] >= limit_start || continue
+        if check_v
+            vworst = max(vworst, V[i] - vhi_allow, vlo_allow - V[i])
+        end
+        aworst = max(aworst, A[i] - amax, amin - A[i])
+    end
+    check_v && vworst > 0 &&
+        push!(viol.vlim, string(repro, " | v exceeds allowed band by ", repr(vworst),
+            " (post-brake v=", repr(spb.v), ")"))
+    aworst > 1e-6 &&
+        push!(viol.alim, string(repro, " | a exceeds limits by ", repr(aworst)))
+
+    if check_trapz
+        h = step(ts)
+        maxa = max(abs(amax), abs(amin), maximum(abs, A))
+        tol = max(1e-8, h^2 * maxa) * 10
+        worst = 0.0
+        for i in 1:length(ts)-1
+            worst = max(worst, abs(P[i+1] - P[i] - h * (V[i] + V[i+1]) / 2))
+        end
+        worst <= tol ||
+            push!(viol.trapz, string(repro, " | trapezoid error ", repr(worst), " > tol ", repr(tol)))
+    end
+    return
+end
+
+#=============================================================================
+ Property tests
+=============================================================================#
+
+@testset "Property tests" begin
+
+    @testset "Single-DOF position, states within limits" begin
+        Random.seed!(0x20260704)
+        rng = Random.default_rng()
+        viol = _pt_new_viol()
+        known_err = String[]
+        n_extreme = 0
+        for _ in 1:2000
+            lim = _pt_rand_limiter(rng)
+            (; vmax, vmin, amax, amin) = lim
+            p0 = _pt_rand_in(rng, -10.0, 10.0)
+            pf = _pt_rand_in(rng, -10.0, 10.0)
+            v0 = _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            vf = _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            a0 = _pt_rand_in(rng, 0.9amin, 0.9amax)
+            af = _pt_rand_af(rng, lim, vf; frac = 0.9)
+            extreme = _pt_excess_ratio(lim, v0, a0) > _PT_EXTREME_RATIO
+            n_extreme += extreme
+            repro = _pt_repro(lim; p0, v0, a0, pf, vf, af)
+            prof = try
+                calculate_trajectory(lim; pf, p0, v0, a0, vf, af)
+            catch e
+                msg = string(repro, " | threw: ", sprint(showerror, e))
+                push!(extreme ? known_err : viol.err, msg)
+                continue
+            end
+            _pt_check_profile!(viol, lim, prof, repro; pf, vf, af,
+                nsamples = 500, check_trapz = true)
+        end
+        @test _pt_dump("solver exceptions", viol.err) == 0
+        @test _pt_dump("final state", viol.final) == 0
+        @test _pt_dump("velocity limits", viol.vlim) == 0
+        @test _pt_dump("acceleration limits", viol.alim) == 0
+        @test _pt_dump("jerk limit", viol.jerk) == 0
+        @test _pt_dump("trapezoid consistency", viol.trapz) == 0
+        # Loose ceiling on the known extreme-state failure class (FIXME above)
+        @test _pt_dump_known("solver exceptions", known_err, n_extreme) <= 0.5 * n_extreme
+    end
+
+    @testset "Single-DOF brake cases (initial state outside limits)" begin
+        Random.seed!(0x20260704)
+        rng = Random.default_rng()
+        viol = _pt_new_viol()
+        known_err = String[]
+        n_extreme = 0
+        for _ in 1:1000
+            lim = _pt_rand_limiter(rng)
+            (; vmax, vmin, amax, amin) = lim
+            p0 = _pt_rand_in(rng, -10.0, 10.0)
+            pf = _pt_rand_in(rng, -10.0, 10.0)
+            mode = rand(rng, 1:3) # 1: v0 outside, 2: a0 outside, 3: both outside
+            v0 = mode == 2 ? _pt_rand_in(rng, 0.9vmin, 0.9vmax) : _pt_outside(rng, vmin, vmax)
+            a0 = mode == 1 ? _pt_rand_in(rng, 0.9amin, 0.9amax) : _pt_outside(rng, amin, amax)
+            if rand(rng) < 0.5
+                vf = 0.0
+                af = 0.0
+            else
+                vf = _pt_rand_in(rng, 0.5vmin, 0.5vmax)
+                af = _pt_rand_af(rng, lim, vf; frac = 0.5)
+            end
+            extreme = _pt_excess_ratio(lim, v0, a0) > _PT_EXTREME_RATIO
+            n_extreme += extreme
+            repro = _pt_repro(lim; p0, v0, a0, pf, vf, af)
+            prof = try
+                calculate_trajectory(lim; pf, p0, v0, a0, vf, af)
+            catch e
+                msg = string(repro, " | threw: ", sprint(showerror, e))
+                push!(extreme ? known_err : viol.err, msg)
+                continue
+            end
+            _pt_check_profile!(viol, lim, prof, repro; pf, vf, af,
+                nsamples = 500, check_trapz = true)
+        end
+        @test _pt_dump("solver exceptions", viol.err) == 0
+        @test _pt_dump("final state", viol.final) == 0
+        @test _pt_dump("velocity limits after brake", viol.vlim) == 0
+        @test _pt_dump("acceleration limits after brake", viol.alim) == 0
+        @test _pt_dump("jerk limit", viol.jerk) == 0
+        @test _pt_dump("trapezoid consistency", viol.trapz) == 0
+        @test _pt_dump_known("solver exceptions", known_err, n_extreme) <= 0.5 * n_extreme
+    end
+
+    @testset "Multi-DOF synchronization" begin
+        Random.seed!(0x20260704)
+        rng = Random.default_rng()
+        viol = _pt_new_viol()
+        sync = String[]
+        known_err = String[]
+        n_extreme = 0
+        ncases = 400
+        nbrake = 100 # cases where exactly one DOF has v0 outside its limits
+        for case in 1:ncases
+            ndof = rand(rng, 2:5)
+            lims = [_pt_rand_limiter(rng) for _ in 1:ndof]
+            p0 = [_pt_rand_in(rng, -10.0, 10.0) for _ in 1:ndof]
+            pf = [_pt_rand_in(rng, -10.0, 10.0) for _ in 1:ndof]
+            v0 = [_pt_rand_in(rng, 0.9l.vmin, 0.9l.vmax) for l in lims]
+            vf = [_pt_rand_in(rng, 0.9l.vmin, 0.9l.vmax) for l in lims]
+            a0 = [_pt_rand_in(rng, 0.9l.amin, 0.9l.amax) for l in lims]
+            af = [_pt_rand_af(rng, lims[i], vf[i]; frac = 0.9) for i in 1:ndof]
+            if case > ncases - nbrake
+                bdof = rand(rng, 1:ndof)
+                v0[bdof] = _pt_outside(rng, lims[bdof].vmin, lims[bdof].vmax)
+            end
+            extreme = any(_pt_excess_ratio(lims[i], v0[i], a0[i]) > _PT_EXTREME_RATIO for i in 1:ndof)
+            n_extreme += extreme
+            repro = string("lims=[", join((_pt_repro(l) for l in lims), ", "),
+                "], p0=", repr(p0), ", v0=", repr(v0), ", a0=", repr(a0),
+                ", pf=", repr(pf), ", vf=", repr(vf), ", af=", repr(af))
+            profs = try
+                calculate_trajectory(lims; pf, p0, v0, a0, vf, af)
+            catch e
+                msg = string(repro, " | threw: ", sprint(showerror, e))
+                push!(extreme ? known_err : viol.err, msg)
+                continue
+            end
+            durs = duration.(profs)
+            if !all(isfinite, durs) || maximum(durs) - minimum(durs) > 1e-9
+                push!(sync, string(repro, " | durations ", repr(durs)))
+            end
+            for i in 1:ndof
+                _pt_check_profile!(viol, lims[i], profs[i], string(repro, " | dof=", i);
+                    pf = pf[i], vf = vf[i], af = af[i], nsamples = 300)
+            end
+        end
+        @test _pt_dump("solver exceptions", viol.err) == 0
+        @test _pt_dump("duration synchronization", sync) == 0
+        @test _pt_dump("final state", viol.final) == 0
+        @test _pt_dump("velocity limits", viol.vlim) == 0
+        @test _pt_dump("acceleration limits", viol.alim) == 0
+        @test _pt_dump("jerk limit", viol.jerk) == 0
+        @test _pt_dump_known("solver exceptions", known_err, n_extreme) <= 0.5 * n_extreme
+    end
+
+    @testset "Velocity interface" begin
+        Random.seed!(0x20260704)
+        rng = Random.default_rng()
+        viol = _pt_new_viol()
+        tf_dur = String[]
+        tf_final = String[]
+        tf_throw_repros = String[]
+        tf_attempts = 0
+        ncases = 800
+        for case in 1:ncases
+            lim = _pt_rand_limiter(rng)
+            (; vmax, vmin, amax, amin) = lim
+            v0 = _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            vf = _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            # Last quarter of the cases: a0 outside limits (velocity brake)
+            a0 = case > 600 ? _pt_outside(rng, amin, amax) : _pt_rand_in(rng, 0.9amin, 0.9amax)
+            af = _pt_rand_in(rng, 0.9amin, 0.9amax)
+            repro = _pt_repro(lim; v0, a0, vf, af)
+            prof = try
+                calculate_velocity_trajectory(lim; vf, v0, a0, af)
+            catch e
+                push!(viol.err, string(repro, " | threw: ", sprint(showerror, e)))
+                continue
+            end
+            # The velocity interface does not enforce vmax; do not check v limits
+            _pt_check_profile!(viol, lim, prof, repro; vf, af,
+                nsamples = 300, check_v = false)
+
+            # Half the cases: also request a comfortably longer duration.
+            # Throwing is allowed here (blocked duration intervals exist for
+            # af != 0); the throw-rate is asserted below.
+            if case % 2 == 0
+                tf = duration(prof) + 0.5
+                tf_attempts += 1
+                prof2 = try
+                    calculate_velocity_trajectory(lim; vf, v0, a0, af, tf)
+                catch e
+                    push!(tf_throw_repros, string(repro, " | tf=", repr(tf)))
+                    nothing
+                end
+                if prof2 !== nothing
+                    abs(duration(prof2) - tf) <= 1e-6 ||
+                        push!(tf_dur, string(repro, " | tf=", repr(tf),
+                            " but duration=", repr(duration(prof2))))
+                    s2 = evaluate_at(prof2, duration(prof2))
+                    (_pt_close(s2.v, vf) && _pt_close(s2.a, af)) ||
+                        push!(tf_final, string(repro, " | tf=", repr(tf),
+                            " final state ", s2, " != target"))
+                end
+            end
+        end
+        @test _pt_dump("solver exceptions", viol.err) == 0
+        @test _pt_dump("final state", viol.final) == 0
+        @test _pt_dump("acceleration limits after brake", viol.alim) == 0
+        @test _pt_dump("jerk limit", viol.jerk) == 0
+        @test _pt_dump("tf-case duration", tf_dur) == 0
+        @test _pt_dump("tf-case final state", tf_final) == 0
+        tf_throws = length(tf_throw_repros)
+        if tf_throws > 0
+            println("  [tf-case throws]: ", tf_throws, " of ", tf_attempts,
+                " (allowed below 20%)")
+        end
+        @test tf_throws < 0.2 * tf_attempts
+    end
+
+    @testset "Determinism (no stale work-buffer state)" begin
+        Random.seed!(0x20260704)
+        rng = Random.default_rng()
+        mismatch = String[]
+        for _ in 1:200
+            lim = _pt_rand_limiter(rng)
+            (; vmax, vmin, amax, amin) = lim
+            p0 = _pt_rand_in(rng, -10.0, 10.0)
+            pf = _pt_rand_in(rng, -10.0, 10.0)
+            # Quarter of the cases start outside the limits to exercise the brake buffer
+            v0 = rand(rng) < 0.25 ? _pt_outside(rng, vmin, vmax) : _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            vf = _pt_rand_in(rng, 0.9vmin, 0.9vmax)
+            a0 = _pt_rand_in(rng, 0.9amin, 0.9amax)
+            af = _pt_rand_af(rng, lim, vf; frac = 0.9)
+            # A different problem solved in between must not change the result
+            dirty = (; pf = _pt_rand_in(rng, -10.0, 10.0),
+                v0 = _pt_rand_in(rng, 0.5vmin, 0.5vmax),
+                a0 = _pt_rand_in(rng, 0.5amin, 0.5amax))
+            repro = _pt_repro(lim; p0, v0, a0, pf, vf, af)
+            prof1 = try
+                calculate_trajectory(lim; pf, p0, v0, a0, vf, af)
+            catch
+                continue # exceptions are covered by the other testsets
+            end
+            try
+                calculate_trajectory(lim; pf = dirty.pf, v0 = dirty.v0, a0 = dirty.a0)
+            catch
+            end
+            prof2 = try
+                calculate_trajectory(lim; pf, p0, v0, a0, vf, af)
+            catch e
+                push!(mismatch, string(repro, " | second call threw: ", sprint(showerror, e)))
+                continue
+            end
+            if duration(prof1) !== duration(prof2)
+                push!(mismatch, string(repro, " | durations ", repr(duration(prof1)),
+                    " vs ", repr(duration(prof2))))
+            end
+            for _ in 1:10
+                t = _pt_rand_in(rng, 0.0, 1.05 * duration(prof1))
+                s1 = evaluate_at(prof1, t)
+                s2 = evaluate_at(prof2, t)
+                if !(s1.p === s2.p && s1.v === s2.v && s1.a === s2.a && s1.j === s2.j)
+                    push!(mismatch, string(repro, " | t=", repr(t), ": ", s1, " vs ", s2))
+                end
+            end
+        end
+        @test _pt_dump("determinism", mismatch) == 0
+    end
+
+end

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -1,0 +1,275 @@
+using TrajectoryLimiters
+using Test
+
+# Deterministic pseudo-random generator (LCG) to avoid a Random test dependency.
+# Returns a closure producing uniform values in [0, 1).
+function make_lcg(seed::UInt64)
+    state = Ref(seed)
+    function ()
+        state[] = state[] * 0x5851f42d4c957f2d + 0x14057b7ef767814f
+        return (state[] >> 11) / 9.007199254740992e15
+    end
+end
+
+# Collect the Roots iterator via explicit iteration (Base.length reports the raw
+# stored count including negative roots, so collect cannot be used directly)
+function roots_to_vector(r)
+    vals = Float64[]
+    for x in r
+        push!(vals, x)
+    end
+    vals
+end
+
+@testset "Regression tests for C++-alignment fixes" begin
+
+    @testset "Brake with nonzero target velocity" begin
+        # v0 outside vmax triggers a brake; nonzero vf triggers collection mode.
+        # This combination used to throw a TypeError from a mistyped brake kwarg.
+        lim = JerkLimiter(; vmax=1.0, amax=1.0, jmax=1.0)
+        prof = calculate_trajectory(lim; p0=0.0, pf=5.0, v0=3.0, vf=0.5)
+        @test prof isa RuckigProfile
+        @test prof.brake_duration > 0
+        p, v, a, _ = evaluate_at(prof, duration(prof))
+        @test p ≈ 5.0 atol=1e-6
+        @test v ≈ 0.5 atol=1e-6
+        @test a ≈ 0.0 atol=1e-6
+
+        # Same input through the multi-DOF entry point
+        profs = calculate_trajectory([lim]; pf=[5.0], v0=[3.0], vf=[0.5])
+        @test length(profs) == 1
+        p, v, a, _ = evaluate_at(profs[1], duration(profs[1]))
+        @test p ≈ 5.0 atol=1e-6
+        @test v ≈ 0.5 atol=1e-6
+    end
+
+    @testset "Zero-limits coast with negative displacement" begin
+        # jmax of zero takes the zero-limits path; the negative-displacement case
+        # used to be rejected because pd-swapped limits were passed to the
+        # direction-unaware single-step check
+        lim = JerkLimiter(; vmax=10.0, vmin=-10.0, amax=1.0, amin=-1.0, jmax=0.0)
+        prof_neg = calculate_trajectory(lim; p0=0.0, pf=-1.0, v0=-1.0, vf=-1.0)
+        @test duration(prof_neg) ≈ 1.0
+        p, v, _, _ = evaluate_at(prof_neg, duration(prof_neg))
+        @test p ≈ -1.0 atol=1e-6
+        @test v ≈ -1.0 atol=1e-6
+
+        # Mirrored positive case must give the same duration
+        prof_pos = calculate_trajectory(lim; p0=0.0, pf=1.0, v0=1.0, vf=1.0)
+        @test duration(prof_pos) ≈ duration(prof_neg)
+    end
+
+    @testset "Multi-DOF synchronization with a braking DOF" begin
+        # DOF 1 starts above its velocity limit and needs a brake pre-trajectory;
+        # the brake used to be dropped during step-2 re-timing
+        lims = [
+            JerkLimiter(; vmax=1.0, amax=2.0, jmax=20.0),
+            JerkLimiter(; vmax=10.0, amax=20.0, jmax=200.0),
+        ]
+        pf = [3.0, 1.0]
+        v0 = [2.5, 0.0]
+        profs = calculate_trajectory(lims; pf, v0)
+        @test profs[1].brake_duration > 0
+
+        T1 = duration(profs[1])
+        T2 = duration(profs[2])
+        @test T1 ≈ T2 atol=1e-9
+
+        for i in 1:2
+            p, v, a, _ = evaluate_at(profs[i], T1)
+            @test p ≈ pf[i] atol=1e-6
+            @test v ≈ 0.0 atol=1e-6
+            @test a ≈ 0.0 atol=1e-6
+        end
+
+        # After the brake, DOF 1 must respect its velocity limits
+        bd = profs[1].brake_duration
+        vs = [evaluate_at(profs[1], t).v for t in range(bd, T1, length=2000)]
+        @test maximum(vs) <= lims[1].vmax + 1e-6
+        @test minimum(vs) >= lims[1].vmin - 1e-6
+    end
+
+    @testset "AccelerationLimiter evaluate_at accelerations" begin
+        # Per-phase accelerations from evaluate_at used to be wrong
+        lim = AccelerationLimiter(; vmax=1.0, amax=2.0)
+        prof = calculate_trajectory(lim; pf=3.0)
+        Ttot = duration(prof)
+        bd = prof.brake_duration
+
+        # Three-phase profile: accelerate, coast, decelerate
+        @test prof.t[1] > 0
+        @test prof.t[2] > 0
+        @test prof.t[3] > 0
+
+        t_acc = bd + prof.t[1] / 2
+        t_coast = bd + prof.t_sum[1] + prof.t[2] / 2
+        t_dec = bd + prof.t_sum[2] + prof.t[3] / 2
+
+        @test evaluate_at(prof, t_acc).a ≈ lim.amax atol=1e-9
+        @test abs(evaluate_at(prof, t_coast).v) ≈ lim.vmax atol=1e-9
+        @test evaluate_at(prof, t_coast).a ≈ 0.0 atol=1e-9
+        @test evaluate_at(prof, t_dec).a ≈ lim.amin atol=1e-9
+
+        # a(t) must match d/dt v(t) away from phase boundaries
+        h = 1e-5
+        breaks = [bd; bd .+ cumsum(collect(prof.t))]
+        fd_err = 0.0
+        for t in range(2h, Ttot - 2h, length=400)
+            any(b -> abs(t - b) < 2h, breaks) && continue
+            fd = (evaluate_at(prof, t + h).v - evaluate_at(prof, t - h).v) / (2h)
+            fd_err = max(fd_err, abs(evaluate_at(prof, t).a - fd))
+        end
+        @test fd_err < 1e-6
+    end
+
+    @testset "Velocity interface brake displacement" begin
+        # a0 outside amax forces a brake; the brake displacement used to be
+        # dropped from the position samples
+        lim = JerkLimiter(; vmax=1.0, amax=1.0, jmax=1.0)
+        prof = calculate_velocity_trajectory(lim; v0=0.0, a0=3.0, vf=0.0)
+        @test prof.brake_duration > 0
+
+        Ttot = duration(prof)
+        ts = range(0, Ttot, length=20_001)
+        _, vs, _, _ = evaluate_at(prof, ts)
+        dt = step(ts)
+        pd_int = dt * (sum(vs) - (vs[1] + vs[end]) / 2)
+
+        p_end = evaluate_at(prof, Ttot).p
+        p_start = evaluate_at(prof, 0.0).p
+        @test p_end - p_start ≈ pd_int atol=1e-4
+        @test prof.pf ≈ p_end atol=1e-9
+    end
+
+    @testset "Velocity interface min-time optimality" begin
+        # The solver used to return the first valid strategy instead of the
+        # minimal-duration one. If the returned duration is minimal, requesting a
+        # slightly shorter tf must be infeasible
+        lim = JerkLimiter(; vmax=1.0, amax=1.0, jmax=1.0)
+        rand01 = make_lcg(UInt64(1))
+        n_checked = 0
+        for _ in 1:200
+            v0 = 1.8 * rand01() - 0.9
+            a0 = 1.8 * rand01() - 0.9
+            vf = 1.8 * rand01() - 0.9
+            af = 1.8 * rand01() - 0.9
+            prof = calculate_velocity_trajectory(lim; v0, a0, vf, af)
+            T = duration(prof)
+            _, v, a, _ = evaluate_at(prof, T)
+            @test v ≈ vf atol=1e-6
+            @test a ≈ af atol=1e-6
+            T < 1e-2 && continue
+            n_checked += 1
+            @test_throws Exception calculate_velocity_trajectory(lim; v0, a0, vf, af, tf=0.9T)
+        end
+        @test n_checked > 150
+    end
+
+    @testset "Waypoint trajectory sample integrity" begin
+        # The first sample of each segment (the exact waypoint state) used to be
+        # dropped; segment durations are generally not multiples of Ts
+        lim = JerkLimiter(; vmax=1.0, amax=5.0, jmax=50.0)
+        Ts = 0.001
+        waypoints = [(p=0.0,), (p=1.0,), (p=0.5,)]
+        ts, ps, vs, as, js = calculate_waypoint_trajectory(lim, waypoints, Ts)
+
+        @test all(>(0), diff(ts))
+        @test maximum(diff(ts)) <= 1.5Ts
+
+        @test ps[1] ≈ 0.0 atol=1e-6
+        @test any(p -> isapprox(p, 1.0, atol=1e-6), ps)
+        @test any(p -> isapprox(p, 0.5, atol=1e-6), ps)
+        @test ps[end] ≈ 0.5 atol=1e-6
+    end
+
+    @testset "get_first_state_at_position returns first crossing" begin
+        # High initial velocity forces an overshoot past pf; the earliest
+        # crossing must be returned, not a later one
+        lim = JerkLimiter(; vmax=5.0, amax=10.0, jmax=100.0)
+        pf = 1.0
+        prof = calculate_trajectory(lim; pf, v0=4.5)
+        ext = get_position_extrema(prof)
+        @test ext.max > pf + 1e-3
+
+        found, t_first = get_first_state_at_position(prof, pf)
+        @test found
+        @test evaluate_at(prof, t_first).p ≈ pf atol=1e-6
+        # The first crossing happens before the trajectory ends at pf
+        @test t_first < duration(prof) - 1e-6
+
+        # No crossing on a fine grid before the reported time
+        ts = range(0, duration(prof), length=100_000)
+        ps, _, _, _ = evaluate_at(prof, ts)
+        i_cross = findfirst(>=(pf - 1e-9), ps)
+        @test i_cross !== nothing
+        @test abs(ts[i_cross] - t_first) <= 2 * step(ts)
+    end
+
+    @testset "Cubic solver domain robustness and Roots iteration" begin
+        r = TrajectoryLimiters.Roots{Float64}()
+
+        # Triple root at unity with the constant coefficient perturbed by ulps;
+        # the acos argument used to be able to drift outside its domain
+        for k in -5:5
+            d = -1.0 + k * eps(1.0)
+            TrajectoryLimiters.solve_cubic_real!(r, 1.0, -3.0, 3.0, d)
+            vals = roots_to_vector(r)
+            @test !isempty(vals)
+            @test all(x -> abs(x - 1) < 1e-3, vals)
+        end
+
+        # Near-double root: (x-1)^2 (x-1-delta) with shrinking delta
+        for k in 1:8, s in (-1.0, 1.0)
+            delta = s * 10.0^-k
+            TrajectoryLimiters.solve_cubic_real!(r, 1.0, -(3 + delta), 3 + 2delta, -(1 + delta))
+            vals = roots_to_vector(r)
+            @test !isempty(vals)
+            @test all(x -> abs(x - 1) <= abs(delta) + 1e-3, vals)
+        end
+
+        # Symmetric near-triple roots (x-1)^3 - delta^2 (x-1) with negative
+        # discriminant exercise the trigonometric branch
+        for delta in (0.02, 0.05, 0.1)
+            TrajectoryLimiters.solve_cubic_real!(r, 1.0, -3.0, 3 - delta^2, -1 + delta^2)
+            vals = roots_to_vector(r)
+            @test length(vals) == 3
+            @test all(x -> abs(x - 1) <= delta + 1e-6, vals)
+        end
+
+        # Iteration must return non-negative roots in ascending order
+        TrajectoryLimiters.clear!(r)
+        for x in (3.0, -1.0, 0.5, 2.0)
+            push!(r, x)
+        end
+        @test roots_to_vector(r) == [0.5, 2.0, 3.0]
+    end
+
+    @testset "Multi-DOF step-2 re-timing with nonzero target velocities" begin
+        # Nonzero vf takes collection mode and forces step-2 re-timing of the
+        # faster DOF; the duration gate and step-2 fallbacks must cooperate
+        lims = [
+            JerkLimiter(; vmax=2.0, amax=5.0, jmax=50.0),
+            JerkLimiter(; vmax=3.0, amax=8.0, jmax=80.0),
+        ]
+        pf = [1.0, 0.4]
+        vf = [0.5, 0.2]
+        profs = calculate_trajectory(lims; pf, vf)
+
+        T1 = duration(profs[1])
+        T2 = duration(profs[2])
+        @test T1 ≈ T2 atol=1e-9
+
+        for i in 1:2
+            p, v, a, _ = evaluate_at(profs[i], T1)
+            @test p ≈ pf[i] atol=1e-6
+            @test v ≈ vf[i] atol=1e-6
+
+            lim = lims[i]
+            _, vs, as, js = evaluate_at(profs[i], range(0, T1, length=2000))
+            @test all(v -> lim.vmin - 1e-6 <= v <= lim.vmax + 1e-6, vs)
+            @test all(a -> lim.amin - 1e-6 <= a <= lim.amax + 1e-6, as)
+            @test all(j -> abs(j) <= lim.jmax + 1e-6, js)
+        end
+    end
+
+end

--- a/test/test_ruckig.jl
+++ b/test/test_ruckig.jl
@@ -1245,13 +1245,29 @@ end
         profile_opt = calculate_velocity_trajectory(lim; v0, a0, vf, af)
         tf_min = duration(profile_opt)
 
-        # Request longer time
-        tf = tf_min + 0.05 + 0.2 * rand()
-        profile = calculate_velocity_trajectory(lim; v0, a0, vf, af, tf)
-        @test duration(profile) ≈ tf atol=1e-6
-        _, vf_actual, af_actual, _ = profile(duration(profile))
-        @test vf_actual ≈ vf atol=1e-5
-        @test af_actual ≈ af atol=1e-5
+        # Request a longer duration. With af != 0 a blocked interval of
+        # infeasible durations can exist just above the minimum (the same
+        # phenomenon as the blocked intervals of the position interface), so
+        # escalate the offset until a feasible duration is found
+        profile = nothing
+        tf = tf_min
+        for offset in (0.05 + 0.2 * rand(), 0.5, 1.0, 2.0, 5.0)
+            tf = tf_min + offset
+            try
+                profile = calculate_velocity_trajectory(lim; v0, a0, vf, af, tf)
+                break
+            catch
+                profile = nothing
+            end
+        end
+        if profile === nothing
+            @test false  # no feasible synchronized duration found in the sweep
+        else
+            @test duration(profile) ≈ tf atol=1e-6
+            _, vf_actual, af_actual, _ = profile(duration(profile))
+            @test vf_actual ≈ vf atol=1e-5
+            @test af_actual ≈ af atol=1e-5
+        end
     end
 
     GC.gc(true)


### PR DESCRIPTION
A systematic module-by-module review of the ruckig port against the C++ reference ([pantor/ruckig](https://github.com/pantor/ruckig) v0.17.3) found 20 confirmed bugs and a set of semantic divergences, all in paths not covered by the existing test suite. Every finding was adversarially verified against the C++ sources, with runtime reproducers where constructible.

## Highlights (crashes / wrong results)

- **Braking + nonzero target velocity threw a `TypeError`**: the `brake` keyword of the step-1 collection functions was annotated `Union{RuckigProfile,Nothing}` but receives a `BrakeProfile`. Reproduced on ~18% of random braking inputs.
- **Multi-DOF step-2 silently dropped brake pre-trajectories** (used the raw pre-brake state and the full synchronized duration, and rebuilt profiles without their brake).
- **All negative-displacement zero-limit trajectories were rejected** (direction-swapped limits passed where C++ passes unswapped ones).
- **`AccelerationLimiter` returned wrong accelerations from `evaluate_at`** (per-phase acceleration array shifted by one phase: `aMax` during coast, `0` during decel).
- **Velocity interface**: brake displacement dropped from positions, `pf` stored as 0, min-time result non-optimal for `af ≠ 0`.
- **`calculate_waypoint_trajectory` lost the exact waypoint sample** whenever a segment duration was not a multiple of `Ts`.
- **`get_first_state_at_position` could return a later crossing than the first** (unsorted root iteration; `Roots` now iterates ascending like the C++ `roots::Set`); `solve_cubic_real!` could throw a `DomainError` from an unclamped `acos`.
- **`check!` applied the C++ `set_limits=true` acceleration snaps unconditionally**, corrupting step-2 `ACC1`/`ACC0_ACC1` candidates; several step-2 functions aborted entirely on degenerate denominators where C++ tries the remaining solution blocks; `check_step2!` enforced a duration gate the C++ has commented out.

The full list (including the smaller C++-alignment items: block boundaries now include brake durations, cyclic index order in `calculate_block!`, the corrected "Three step - Removed aMax" formula, monic-derivative tolerances in `time_vel_step2!`, dead-code cleanups) is in the commit message.

## Tests

- `test/test_regression.jl`: one testset per fixed bug, built from the verified reproducers (718 assertions).
- `test/test_properties.jl`: seeded randomized property suite (~4400 cases): final-state accuracy, per-DOF limit respect incl. brake phases, trajectory continuity, multi-DOF duration synchronization, velocity interface, work-buffer determinism.
- The random velocity time-sync test now escalates the requested duration: with `af ≠ 0` a blocked interval of infeasible durations legitimately exists just above the minimum (same phenomenon as the position-interface blocked intervals); the previously returned non-minimal duration had masked this.

Full suite: 21364 pass, 3 pre-existing broken, 0 failures.

## Known remaining edge case (documented, not fixed here)

For extreme out-of-limit initial states (velocity excursions >20x the velocity band), step 1 can fail to find a profile from the post-brake state and throws. Tracked with a reproducer in a FIXME in `test/test_properties.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)