### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TrajectoryLimiters"
 uuid = "9792e600-fe43-4e4e-833b-462f466b8006"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Fredrik Bagge Carlson"]
 
 [deps]


### PR DESCRIPTION
Version bump for the phase-synchronization feature merged in #17, so it can be registered and depended on with `TrajectoryLimiters = "0.1.5"` compat (MultibodyComponents' migration to the upstream phase sync requires it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)